### PR TITLE
Issue #25: cast numbers to integers

### DIFF
--- a/src/Lidsys/Football/Service/ScheduleService.php
+++ b/src/Lidsys/Football/Service/ScheduleService.php
@@ -186,6 +186,10 @@ class ScheduleService
             )
         );
         while ($game = $query->fetch()) {
+            if ($game['away_score'] || $game['home_score']) {
+                $game['away_score'] = intval($game['away_score']);
+                $game['home_score'] = intval($game['home_score']);
+            }
             $games[] = $game;
         }
 


### PR DESCRIPTION
Comparing the numbers as strings was resulting in an ASCII
sort instead of a numeric sort, which meant the wrong team
was sometimes shown as the winning team
