### PR TITLE
Fix legacy assets not being cached

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -23,6 +23,10 @@ $app->before(function (Request $request) use ($app) {
         return;
     }
 
+    if (strpos($request->getPathInfo(), '/app/asset/') === 0) {
+        return;
+    }
+
     session_start([
         'lifetime' => strtotime("2 hours") - time(),
         'path'     => '/',


### PR DESCRIPTION
When `session_start()` is called, an `Expires` header is set to a value
in the distant past. This causes Cloudflare to not cache the assets. We
should not be starting a session or authenticating for asset routes.