### PR TITLE
Keep redirecting to Silex app for now

### DIFF
--- a/src/Pages/HomePage.php
+++ b/src/Pages/HomePage.php
@@ -6,6 +6,9 @@ class HomePage extends BasePage
 {
     public function invoke()
     {
+        $this->redirectToUrl('/app');
+        return;
+
         $this->set('title', 'Pickem');
         $this->render('home.phtml');
     }


### PR DESCRIPTION
Right now a different team standings page is loaded depending on whether
a link is clicked from Silex-app versus The-app. Until we have all pages
moved over to The-app, let's use the Silex-app so that we do not need to
update the navigation in the Silex-app.